### PR TITLE
Add site typography to CMS news preview pane

### DIFF
--- a/src/site/admin/index.html
+++ b/src/site/admin/index.html
@@ -11,6 +11,8 @@
     <!-- Decap CMS -->
     <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
     <script>
+      const { createClass, h } = CMS;
+
       // Register site styles for preview pane to match website typography
       CMS.registerPreviewStyle("/css/styles.css");
 

--- a/src/site/admin/index.html
+++ b/src/site/admin/index.html
@@ -10,5 +10,83 @@
   <body>
     <!-- Decap CMS -->
     <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+    <script>
+      // Register site styles for preview pane to match website typography
+      CMS.registerPreviewStyle("/css/styles.css");
+
+      // Custom preview template for blog posts that matches the site's post layout
+      const PostPreview = createClass({
+        render: function () {
+          const entry = this.props.entry;
+          const title = entry.getIn(["data", "title"]) || "";
+          const date = entry.getIn(["data", "date"]);
+          const image = entry.getIn(["data", "image"]);
+          const tags = entry.getIn(["data", "tags"]);
+
+          return h(
+            "article",
+            { className: "bg-white py-12" },
+            h(
+              "div",
+              { className: "mx-auto max-w-3xl px-6" },
+              h(
+                "header",
+                { className: "mb-10" },
+                h(
+                  "h1",
+                  {
+                    className:
+                      "mb-4 text-4xl font-bold tracking-tight text-gray-900",
+                  },
+                  title
+                ),
+                date &&
+                  h(
+                    "time",
+                    { className: "text-gray-500" },
+                    new Date(date).toLocaleDateString("en-GB", {
+                      day: "numeric",
+                      month: "long",
+                      year: "numeric",
+                    })
+                  ),
+                tags &&
+                  tags.size > 0 &&
+                  h(
+                    "div",
+                    { className: "mt-4 flex flex-wrap gap-2" },
+                    tags
+                      .map(tag =>
+                        h(
+                          "span",
+                          {
+                            key: tag,
+                            className:
+                              "rounded-full bg-orange-100 px-3 py-1 text-sm text-orange-700",
+                          },
+                          tag
+                        )
+                      )
+                      .toArray()
+                  )
+              ),
+              image &&
+                h("img", {
+                  src: this.props.getAsset(image).toString(),
+                  alt: "",
+                  className: "mb-10 w-full rounded-lg",
+                }),
+              h(
+                "div",
+                { className: "prose prose-lg prose-orange mx-auto" },
+                this.props.widgetFor("body")
+              )
+            )
+          );
+        },
+      });
+
+      CMS.registerPreviewTemplate("blog", PostPreview);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Register the site's Tailwind CSS in the Decap CMS preview and add
a custom blog post preview template that mirrors the actual post
layout with prose-lg prose-orange typography classes.